### PR TITLE
Fixes issues with old methods in GoogleStorageMixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *.pyc
 *.eggs/
 *.egg-info
+.idea
 mezzanine-git/

--- a/filebrowser_safe/storage.py
+++ b/filebrowser_safe/storage.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 # PYTHON IMPORTS
 import os
 import shutil
+import posixpath
 
 # DJANGO IMPORTS
 from django.core.files.move import file_move_safe
@@ -133,7 +134,7 @@ class GoogleStorageMixin(StorageMixin):
             return False
 
         name = self._normalize_name(self._clean_name(name))
-        dirlist = self.bucket.list(self._encode_name(name))
+        dirlist = self.listdir(self._encode_name(name))
 
         # Check whether the iterator is empty
         for item in dirlist:
@@ -163,6 +164,32 @@ class GoogleStorageMixin(StorageMixin):
 
     def rmtree(self, name):
         name = self._normalize_name(self._clean_name(name))
-        dirlist = self.bucket.list(self._encode_name(name))
+        dirlist = self.listdir(self._encode_name(name))
         for item in dirlist:
             item.delete()
+
+    def _clean_name(self, name):
+        """
+        Cleans the name so that Windows style paths work
+        """
+        return clean_name(name)
+
+
+def clean_name(name):
+    """
+    Cleans the name so that Windows style paths work
+    """
+    # Normalize Windows style paths
+    clean_name = posixpath.normpath(name).replace('\\', '/')
+
+    # os.path.normpath() can strip trailing slashes so we implement
+    # a workaround here.
+    if name.endswith('/') and not clean_name.endswith('/'):
+        # Add a trailing slash as it was stripped.
+        clean_name = clean_name + '/'
+
+    # Given an empty string, os.path.normpath() will return ., which we don't want
+    if clean_name == '.':
+        clean_name = ''
+
+    return clean_name


### PR DESCRIPTION
- Fixes `_clean_name` method, which didn't exist anymore in `storages.backends.gcloud.GoogleCloudStorage`
- Fixes issue with method list in Bucket, since that's not supported any longer. Use of `listdir` instead.
- Add `.idea` to `.gitignore`

**Tested using:**
- Mezzanine==4.3.1                          
- django-storages[google]==1.7.1
- google-cloud-storage==1.14.0