### PR TITLE
Fix cs specification that is breaking compilemessages command

### DIFF
--- a/filebrowser_safe/locale/cs/LC_MESSAGES/django.po
+++ b/filebrowser_safe/locale/cs/LC_MESSAGES/django.po
@@ -322,7 +322,7 @@ msgstr[1] "%(counter) výsledky"
 #: templates/filebrowser/include/toolbar.html:9
 #, python-format
 msgid "%(full_result_count)s total"
-msgstr "%(full_result_count) celkem"
+msgstr "%(full_result_count)s celkem"
 
 #: templates/filebrowser/include/search.html:5
 msgid "Clear Restrictions"


### PR DESCRIPTION
When compiling the czech translations, Django throws

```
CommandError: Execution of msgfmt failed: /home/jan/my-python-project/venv/lib/python3.5/site-packages/filebrowser_safe/locale/cs/LC_MESSAGES/django.po:325: format specifications in 'msgid' and 'msgstr' for argument 'full_result_count' are not the same
msgfmt: found 1 fatal error
```

This fixes the error by making the format specifications in msgid and msgstr match.